### PR TITLE
Use default config values

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -55,7 +55,7 @@ class Plugin extends \Mibew\Plugin\AbstractPlugin implements \Mibew\Plugin\Plugi
      */
     public function __construct($config)
     {
-        $this->config = $config;
+        parent::__construct($config + array('new_thread' => true));
         $this->initialized = true;
     }
 


### PR DESCRIPTION
Setting default values for configs is useful in many cases. Also parent constructor should be invoked to deal with "_weight_" plugin's property.
